### PR TITLE
Add attribute parsing: Form&Render-Elements and Entity

### DIFF
--- a/src/parser/php.rs
+++ b/src/parser/php.rs
@@ -377,6 +377,10 @@ impl PhpParser {
 
     /// Helper function to extract usage example from the preceding comment
     fn extract_usage_example_from_comment(&self, comment_node: &Node) -> Option<String> {
+        if comment_node.kind() != "comment" {
+            return None;
+        }
+
         let comment_text = self.get_node_text(comment_node);
         let start_tag = "@code";
         let end_tag = "@endcode";

--- a/src/parser/php.rs
+++ b/src/parser/php.rs
@@ -274,8 +274,23 @@ impl PhpParser {
                     class_attribute = Some(ClassAttribute::Plugin(DrupalPlugin {
                         plugin_type,
                         plugin_id,
+                        usage_example: None,
                     }));
                 };
+            }
+        }
+
+        // Try to get an usage example for snippet generation.
+        if let Some(attribute) = &mut class_attribute {
+            match attribute {
+                ClassAttribute::Plugin(ref mut drupal_plugin) => {
+                    if let Some(prev_sibling) = node.prev_named_sibling() {
+                        if prev_sibling.kind() == "comment" {
+                            drupal_plugin.usage_example =
+                                self.extract_usage_example_from_comment(&prev_sibling);
+                        }
+                    }
+                }
             }
         }
 
@@ -317,6 +332,16 @@ impl PhpParser {
         // TODO: Look into improving this if we want to extract more than plugin id.
         let parameters_node = node.child_by_field_name("parameters")?;
         for argument in parameters_node.named_children(&mut parameters_node.walk()) {
+            // In the case of f.e `#[FormElement('date')]` there is no `id` field.
+            if self.get_node_text(&argument).starts_with("'")
+                && self.get_node_text(&argument).ends_with("'")
+            {
+                plugin_id = self
+                    .get_node_text(&argument)
+                    .trim_matches(|c| c == '"' || c == '\'')
+                    .to_string();
+                break;
+            }
             let argument_name = argument.child_by_field_name("name")?;
             if self.get_node_text(&argument_name) == "id" {
                 plugin_id = self
@@ -330,6 +355,7 @@ impl PhpParser {
             Ok(plugin_type) => Some(ClassAttribute::Plugin(DrupalPlugin {
                 plugin_id,
                 plugin_type,
+                usage_example: None,
             })),
             Err(_) => None,
         }
@@ -359,5 +385,32 @@ impl PhpParser {
 
     fn get_node_text(&self, node: &Node) -> &str {
         node.utf8_text(self.source.as_bytes()).unwrap_or("")
+    }
+
+    /// Helper function to extract usage example from the preceding comment
+    fn extract_usage_example_from_comment(&self, comment_node: &Node) -> Option<String> {
+        let comment_text = self.get_node_text(comment_node);
+        let start_tag = "@code";
+        let end_tag = "@endcode";
+
+        if let Some(start_index) = comment_text.find(start_tag) {
+            if let Some(end_index) = comment_text.find(end_tag) {
+                if end_index > start_index {
+                    let code_start = start_index + start_tag.len();
+                    let example = comment_text[code_start..end_index].trim();
+                    let cleaned_example = example
+                        .lines()
+                        .map(|line| line.trim_start().strip_prefix("* ").unwrap_or(line))
+                        .collect::<Vec<&str>>();
+
+                    let result = &cleaned_example[..cleaned_example.len() - 1]
+                        .join("\n")
+                        .trim()
+                        .to_string();
+                    return Some(result.to_string());
+                }
+            }
+        }
+        None
     }
 }

--- a/src/parser/php.rs
+++ b/src/parser/php.rs
@@ -274,23 +274,9 @@ impl PhpParser {
                     class_attribute = Some(ClassAttribute::Plugin(DrupalPlugin {
                         plugin_type,
                         plugin_id,
-                        usage_example: None,
+                        usage_example: self.extract_usage_example_from_comment(&comment_node),
                     }));
                 };
-            }
-        }
-
-        // Try to get an usage example for snippet generation.
-        if let Some(attribute) = &mut class_attribute {
-            match attribute {
-                ClassAttribute::Plugin(ref mut drupal_plugin) => {
-                    if let Some(prev_sibling) = node.prev_named_sibling() {
-                        if prev_sibling.kind() == "comment" {
-                            drupal_plugin.usage_example =
-                                self.extract_usage_example_from_comment(&prev_sibling);
-                        }
-                    }
-                }
             }
         }
 
@@ -355,7 +341,9 @@ impl PhpParser {
             Ok(plugin_type) => Some(ClassAttribute::Plugin(DrupalPlugin {
                 plugin_id,
                 plugin_type,
-                usage_example: None,
+                usage_example: self.extract_usage_example_from_comment(
+                    &node.parent()?.parent()?.parent()?.prev_named_sibling()?,
+                ),
             })),
             Err(_) => None,
         }

--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -156,6 +156,8 @@ pub enum DrupalPluginType {
     QueueWorker,
     FieldType,
     DataType,
+    FormElement,
+    RenderElement,
 }
 
 impl TryFrom<&str> for DrupalPluginType {
@@ -167,6 +169,8 @@ impl TryFrom<&str> for DrupalPluginType {
             "QueueWorker" => Ok(DrupalPluginType::QueueWorker),
             "FieldType" => Ok(DrupalPluginType::FieldType),
             "DataType" => Ok(DrupalPluginType::DataType),
+            "FormElement" => Ok(DrupalPluginType::FormElement),
+            "RenderElement" => Ok(DrupalPluginType::RenderElement),
             _ => Err("Unable to convert string to DrupalPluginType"),
         }
     }
@@ -182,6 +186,7 @@ impl fmt::Display for DrupalPluginType {
 pub struct DrupalPlugin {
     pub plugin_type: DrupalPluginType,
     pub plugin_id: String,
+    pub usage_example: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/server/handlers/completion/mod.rs
+++ b/src/server/handlers/completion/mod.rs
@@ -326,9 +326,9 @@ pub fn handle_text_document_completion(request: Request) -> Option<Response> {
 }
 
 fn get_global_snippets() -> Vec<CompletionItem> {
-    let mut snippets: HashMap<String, String> = HashMap::new();
+    let mut snippets = HashMap::new();
     snippets.insert(
-        "batch".to_string(),
+        "batch",
         r#"
 \$storage = \\Drupal::entityTypeManager()->getStorage('$0');
 if (!isset(\$sandbox['ids'])) {
@@ -346,75 +346,58 @@ foreach (\$storage->loadMultiple(\$ids) as \$entity) {
 
 if (\$sandbox['total'] > 0) {
   \$sandbox['#finished'] = (\$sandbox['total'] - count(\$sandbox['ids'])) / \$sandbox['total'];
-}"#
-        .to_string(),
+}"#,
     );
     snippets.insert(
-        "ihdoc".to_string(),
+        "ihdoc",
         r#"
 /**
  * {@inheritdoc}
- */"#
-        .to_string(),
+ */"#,
     );
     snippets.insert(
-        "ensure-instanceof".to_string(),
-        "if (!($1 instanceof $2)) {\n  return$0;\n}".to_string(),
+        "ensure-instanceof",
+        "if (!($1 instanceof $2)) {\n  return$0;\n}",
     );
     snippets.insert(
-        "entity-storage".to_string(),
-        "\\$storage = \\$this->entityTypeManager->getStorage('$0');".to_string(),
+        "entity-storage",
+        "\\$storage = \\$this->entityTypeManager->getStorage('$0');",
     );
     snippets.insert(
-        "entity-load".to_string(),
-        "\\$$1 = \\$this->entityTypeManager->getStorage('$1')->load($0);".to_string(),
+        "entity-load",
+        "\\$$1 = \\$this->entityTypeManager->getStorage('$1')->load($0);",
     );
     snippets.insert(
-        "entity-query".to_string(),
+        "entity-query",
         r#"
 \$ids = \$this->entityTypeManager->getStorage('$1')->getQuery()
   ->accessCheck(${TRUE})
   $0
-  ->execute()"#
-            .to_string(),
+  ->execute()"#,
     );
-    snippets.insert("type".to_string(), "'#type' => '$0',".to_string());
+    snippets.insert("type", "'#type' => '$0',");
+    snippets.insert("title", "'#title' => \\$this->t('$0'),");
+    snippets.insert("description", "'#description' => \\$this->t('$0'),");
+    snippets.insert("attributes", "'#attributes' => [$0],");
     snippets.insert(
-        "title".to_string(),
-        "'#title' => \\$this->t('$0'),".to_string(),
+        "attributes-class",
+        "'#attributes' => [\n  'class' => ['$0'],\n],",
     );
+    snippets.insert("attributes-id", "'#attributes' => [\n  'id' => '$0',\n],");
     snippets.insert(
-        "description".to_string(),
-        "'#description' => \\$this->t('$0'),".to_string(),
-    );
-    snippets.insert(
-        "attributes".to_string(),
-        "'#attributes' => [$0],".to_string(),
-    );
-    snippets.insert(
-        "attributes-class".to_string(),
-        "'#attributes' => [\n  'class' => ['$0'],\n],".to_string(),
-    );
-    snippets.insert(
-        "attributes-id".to_string(),
-        "'#attributes' => [\n  'id' => '$0',\n],".to_string(),
-    );
-    snippets.insert(
-        "type_html_tag".to_string(),
+        "type_html_tag",
         r#"'#type' => 'html_tag',
 '#tag' => '$1',
-'#value' => $0,"#
-            .to_string(),
+'#value' => $0,"#,
     );
     snippets.insert(
-        "type_details".to_string(),
+        "type_details",
         r#"'#type' => 'details',
 '#open' => TRUE,
-'#title' => \$this->t('$0'),"#
-            .to_string(),
+'#title' => \$this->t('$0'),"#,
     );
     snippets.insert(
-        "create".to_string(),
+        "create",
         r#"/**
  * {@inheritdoc}
  */
@@ -422,11 +405,10 @@ public static function create(ContainerInterface \$container) {
   return new static(
     \$container->get('$0'),
   );
-}"#
-        .to_string(),
+}"#,
     );
     snippets.insert(
-        "create-plugin".to_string(),
+        "create-plugin",
         r#"/**
  * {@inheritdoc}
  */
@@ -437,7 +419,7 @@ public static function create(ContainerInterface \$container, array \$configurat
     \$plugin_definition,
     \$container->get('$0'),
   );
-}"#.to_string(),
+}"#,
     );
 
     // Create pre-generated snippets.
@@ -469,10 +451,12 @@ public static function create(ContainerInterface \$container, array \$configurat
             })
         })
         .for_each(|(snippet_key_prefix, plugin_id, usage_example)| {
-            snippets.insert(
-                format!("{}-{}", snippet_key_prefix, plugin_id),
-                usage_example.replace("$", "\\$"),
-            );
+            let key_string: String = format!("{}-{}", snippet_key_prefix, plugin_id);
+            let value_string: String = usage_example.replace("$", "\\$");
+
+            let key: &'static str = Box::leak(key_string.into_boxed_str());
+            let value: &'static str = Box::leak(value_string.into_boxed_str());
+            snippets.insert(key, value);
         });
 
     snippets


### PR DESCRIPTION
Hey,

stumbled on this project and think it's a great idea to have a language server for Drupal. This is already really helpful.
I was digging around in the code base and made some implementations.

**Attribute Parsing**
I've added attributes parsing and also changed the way parse_nodes work, because previously when a class_declaration was parsed, the containing attributes weren't parsed. That way the attributes in that class should also be caught by the match statement.

**Form Elements & Render Elements**
There are two new token types, that pick these up by their attributes.
I have not implemented any annotation based discovery, as those should be converted at some point anyways (https://www.drupal.org/project/drupal/issues/3396165).
Although I'm a bit unsure how the auto completion would work. Since they are both used within `['#type' => '...'`] it depends on the context (are we inside a Form f.e), but I don't think that's that easy to determine.
Maybe Render & Form Elements should always be suggested regardless of context?

**Auto generate snippets**
All picked up Form and Render Elements that have a `@code` and `@endcode` block inside their comment will be available as snippets with either `form-{id}` or `render-{id}`. Unfortunately a lot of these don't have usage examples in earlier versions and I don't think parsing the `getInfo()` method on the Plugin is a good idea. But this should improve with later versions (see screenshot).

**Entity Completion**
ContentEntityTypes are also picked up by attribute. Currently I suggest that completion when `getStorage()` by the entityTypeManager is used.

I hope this PR can help a bit, if not it was still fun to tinker with this a bit.
![form](https://github.com/user-attachments/assets/4a45ab40-577d-4aa2-9c3a-47094895b695)
![form2](https://github.com/user-attachments/assets/7015b3d2-2d9e-47f9-8e46-87557fe0da82)
![user](https://github.com/user-attachments/assets/7a0c207d-53bf-4fa3-b638-9cb43c28d04a)

