### PR TITLE
Extend builder paths for PHP Files (missing hooks)

### DIFF
--- a/src/document_store/mod.rs
+++ b/src/document_store/mod.rs
@@ -32,13 +32,10 @@ pub fn initialize_document_store(root_dir: String) {
     override_builder.add("**/*.routing.yml").unwrap();
     override_builder.add("**/*.permissions.yml").unwrap();
     override_builder.add("**/*.menu.yml").unwrap();
-    override_builder.add("**/src/**/*.php").unwrap();
-    override_builder.add("**/core/lib/**/*.php").unwrap();
+    override_builder.add("**/core/**/*.php").unwrap();
+    override_builder.add("**/modules/**/*.php").unwrap();
     // For now we don't care about interfaces at all.
-    override_builder.add("!**/src/**/*Interface.php").unwrap();
-    override_builder
-        .add("!**/core/lib/**/*Interface.php")
-        .unwrap();
+    override_builder.add("!**/*Interface.php").unwrap();
     override_builder.add("!**/tests/**/*.php").unwrap();
     override_builder.add("!vendor").unwrap();
     override_builder.add("!node_modules").unwrap();


### PR DESCRIPTION
Hey,

I've noticed some missing hooks in the snippets.

An example is [hook_field_widget_single_element_form_alter](https://api.drupal.org/api/drupal/core%21modules%21field%21field.api.php/function/hook_field_widget_single_element_form_alter/11.x).

It's defined in `core/modules/field/field.api.php`. Reason being, the current globs don't pick these up (it's neither in `lib/*` nor `src/*`).

I think it would also be good to include contrib (and possibly custom) modules.

For example when using "group": [group.api.php](https://git.drupalcode.org/project/group/-/blob/3.3.x/group.api.php?ref_type=heads), which usually would be `web/modules/contrib/group/group.api.php`.

Currently some hook definitions are missed, so I suggest extended the glob.